### PR TITLE
Add trim to remove \r

### DIFF
--- a/src/ca/weblite/codename1/db/DAOProvider.java
+++ b/src/ca/weblite/codename1/db/DAOProvider.java
@@ -115,7 +115,7 @@ public class DAOProvider {
                         }
                         cmdBuf.delete(0, cmdBuf.length());
                     }
-                    int num = Integer.parseInt(line.substring(line.indexOf(":")+1, line.length()));
+                    int num = Integer.parseInt(line.substring(line.indexOf(":")+1, line.length()).trim());
                     
                     if ( num != currVersion ){
                         if ( !versionCommands.isEmpty() ){


### PR DESCRIPTION
When the SQL file comes from Windows, a '\r' is added to the '\n' at the end of a line, so the Integer.parseInt throws a NumberFormatException.